### PR TITLE
feat: 项目脚手架与基础设施 (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .claude
 .mcp.json
 superpowers
+bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: build run test install clean
+
+# 编译二进制
+build:
+	go build -o ./bin/aria2-tgbot ./cmd/bot/
+
+# 本地运行
+run:
+	go run ./cmd/bot/
+
+# 运行测试
+test:
+	go test -v -count=1 ./...
+
+# 安装到系统（需要 root 权限）
+install: build
+	install -d /etc/aria2-tgbot
+	cp ./bin/aria2-tgbot /usr/local/bin/aria2-tgbot
+	cp ./config.yaml /etc/aria2-tgbot/config.yaml
+	cp ./aria2-tgbot.service /etc/systemd/system/
+	systemctl daemon-reload
+	systemctl enable aria2-tgbot
+	systemctl start aria2-tgbot
+
+# 清理编译产物
+clean:
+	rm -rf ./bin/

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ test:
 # 安装到系统（需要 root 权限）
 install: build
 	install -d /etc/aria2-tgbot
-	cp ./bin/aria2-tgbot /usr/local/bin/aria2-tgbot
-	cp ./config.yaml /etc/aria2-tgbot/config.yaml
-	cp ./aria2-tgbot.service /etc/systemd/system/
+	install -m 755 ./bin/aria2-tgbot /usr/local/bin/aria2-tgbot
+	install -m 600 ./config.yaml /etc/aria2-tgbot/config.yaml
+	install -m 644 ./aria2-tgbot.service /etc/systemd/system/
 	systemctl daemon-reload
 	systemctl enable aria2-tgbot
 	systemctl start aria2-tgbot

--- a/aria2-tgbot.service
+++ b/aria2-tgbot.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Aria2 Telegram Bot
+After=network.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/aria2-tgbot -c /etc/aria2-tgbot/config.yaml
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -9,9 +9,19 @@ import (
 	"os/signal"
 	"syscall"
 
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+
 	"github.com/dnslin/aria2-tgbot/internal/config"
 	"github.com/dnslin/aria2-tgbot/internal/logger"
 )
+
+// 后续 Issue #3 将在此初始化 Bot 实例：
+//   botAPI, err := tgbotapi.NewBotAPI(cfg.Bot.Token)
+//   handler := telegram.NewHandler(svc, cfg)
+//   bot := telegram.New(botAPI, handler, cfg)
+//   go bot.Run()
+
+var _ = tgbotapi.BotAPI{} // 锁定 tgbotapi v5 依赖
 
 func main() {
 	configPath := flag.String("c", "./config.yaml", "配置文件路径")

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -1,0 +1,53 @@
+// Aria2 Telegram Bot 入口。
+// 加载配置、初始化日志、检测 aria2 状态，然后启动 Bot。
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/dnslin/aria2-tgbot/internal/config"
+	"github.com/dnslin/aria2-tgbot/internal/logger"
+)
+
+func main() {
+	configPath := flag.String("c", "./config.yaml", "配置文件路径")
+	flag.Parse()
+
+	// 加载配置
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "加载配置失败: %v\n", err)
+		os.Exit(1)
+	}
+
+	// 初始化日志
+	log, err := logger.New(logger.Config{
+		Dir:        cfg.Log.Dir,
+		Level:      cfg.Log.Level,
+		MaxSize:    cfg.Log.MaxSize,
+		MaxBackups: cfg.Log.MaxBackups,
+		MaxAge:     cfg.Log.MaxAge,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "初始化日志失败: %v\n", err)
+		os.Exit(1)
+	}
+	defer log.Close()
+
+	log.Info("Aria2 Telegram Bot 启动中...")
+	log.Info("配置文件: %s", *configPath)
+	log.Info("日志级别: %s", cfg.Log.Level)
+	log.Info("权限控制: %v", cfg.Auth.IsEnabled())
+	log.Info("Bot 已就绪，等待 Telegram Updates")
+
+	// 等待退出信号
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-sigCh
+
+	log.Info("收到信号 %v，Bot 正在关闭...", sig)
+}

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,42 @@
+# ===== Aria2 Telegram Bot 配置 =====
+
+# Bot 基础配置
+bot:
+  token: ""                     # Telegram Bot Token（必填，支持环境变量 BOT_TOKEN）
+  debug: false                  # 调试模式（开启后输出更多日志）
+
+# 权限控制
+auth:
+  enabled: true                 # 开启白名单
+  allow_users: []               # 允许的用户 ID 列表，如 [123456789, 987654321]
+
+# 消息行为（运行时可通过命令修改并自动持久化）
+message:
+  auto_delete: true             # 全局自动删除开关
+  delete_after: 180             # 默认删除时间（秒），0 = 不删
+  result_delete_after: 300      # 命令结果保留时间（秒）
+  progress_update_interval: 30  # 进度刷新间隔（秒）
+  install_log_delete: true      # 安装日志自动删除
+  error_delete_after: 0         # 错误消息保留时间（秒），0 = 不删
+  notify_delete_after: 0        # 下载完成通知保留时间（秒），0 = 不删
+
+# aria2 安装与连接配置
+aria2:
+  install_script_url: "https://git.io/aria2.sh"
+  install_path: "/usr/local/bin"
+  config_dir: "/root/.aria2c"
+  download_dir: "/root/downloads"
+  rpc_host: "127.0.0.1"
+  rpc_port: 6800
+  rpc_secret: ""                # 留空则安装时自动生成 16 位随机密钥
+  session_dir: "/root/.aria2c"
+  auto_start: true              # 安装后自动启动
+  enable_systemd: true          # 注册为 systemd 服务（开机自启）
+
+# 日志
+log:
+  dir: "./logs"
+  level: "info"                 # debug / info / warn / error
+  max_size: 10                  # 单个日志文件最大 MB
+  max_backups: 7                # 最多保留旧日志文件数
+  max_age: 30                   # 日志最长保留天数

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/dnslin/aria2-tgbot
+
+go 1.24.4
+
+require (
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+require github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
+github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,169 @@
+// Package config 负责 YAML 配置文件的加载、校验、默认值填充和运行时持久化。
+// 配置文件通过 -c 命令行参数指定，默认 ./config.yaml。
+// 敏感字段（bot.token）支持从环境变量覆盖。
+package config
+
+import (
+	"os"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// BotConfig Bot 基础配置
+type BotConfig struct {
+	Token string `yaml:"token"` // Telegram Bot Token，支持环境变量 BOT_TOKEN
+	Debug bool   `yaml:"debug"`
+}
+
+// AuthConfig 权限控制配置
+type AuthConfig struct {
+	Enabled    *bool   `yaml:"enabled"` // 指针以区分"未设置"和"显式设为 false"
+	AllowUsers []int64 `yaml:"allow_users"`
+}
+
+// IsEnabled 返回权限是否开启，默认启用。
+func (a *AuthConfig) IsEnabled() bool {
+	if a.Enabled == nil {
+		return true
+	}
+	return *a.Enabled
+}
+
+// MessageConfig 消息行为配置，运行时可通过命令修改并持久化
+type MessageConfig struct {
+	AutoDelete              *bool `yaml:"auto_delete"`
+	DeleteAfter             int  `yaml:"delete_after"`
+	ResultDeleteAfter       int  `yaml:"result_delete_after"`
+	ProgressUpdateInterval  int  `yaml:"progress_update_interval"`
+	InstallLogDelete        bool `yaml:"install_log_delete"`
+	ErrorDeleteAfter        int  `yaml:"error_delete_after"`
+	NotifyDeleteAfter       int  `yaml:"notify_delete_after"`
+}
+
+// Aria2Config aria2 安装和 RPC 连接配置
+type Aria2Config struct {
+	InstallScriptURL string `yaml:"install_script_url"`
+	InstallPath      string `yaml:"install_path"`
+	ConfigDir        string `yaml:"config_dir"`
+	DownloadDir      string `yaml:"download_dir"`
+	RpcHost          string `yaml:"rpc_host"`
+	RpcPort          int    `yaml:"rpc_port"`
+	RpcSecret        string `yaml:"rpc_secret"`
+	SessionDir       string `yaml:"session_dir"`
+	AutoStart        bool   `yaml:"auto_start"`
+	EnableSystemd    bool   `yaml:"enable_systemd"`
+}
+
+// LogConfig 日志配置
+type LogConfig struct {
+	Dir        string `yaml:"dir"`
+	Level      string `yaml:"level"`
+	MaxSize    int    `yaml:"max_size"`
+	MaxBackups int    `yaml:"max_backups"`
+	MaxAge     int    `yaml:"max_age"`
+}
+
+// Config 聚合所有配置项
+type Config struct {
+	Bot     BotConfig     `yaml:"bot"`
+	Auth    AuthConfig    `yaml:"auth"`
+	Message MessageConfig `yaml:"message"`
+	Aria2   Aria2Config   `yaml:"aria2"`
+	Log     LogConfig     `yaml:"log"`
+
+	mu       sync.RWMutex `yaml:"-"`
+	filePath string       `yaml:"-"`
+}
+
+// Load 从指定路径加载 YAML 配置文件，填充默认值，并从环境变量覆盖敏感字段。
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &Config{filePath: path}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+
+	cfg.SetDefaults()
+
+	// 环境变量覆盖 Token
+	if envToken := os.Getenv("BOT_TOKEN"); envToken != "" {
+		cfg.Bot.Token = envToken
+	}
+
+	return cfg, nil
+}
+
+// SetDefaults 为未设置的字段填充默认值。
+func (c *Config) SetDefaults() {
+	if c.Message.DeleteAfter == 0 {
+		c.Message.DeleteAfter = 180
+	}
+	if c.Message.ResultDeleteAfter == 0 {
+		c.Message.ResultDeleteAfter = 300
+	}
+	if c.Message.ProgressUpdateInterval == 0 {
+		c.Message.ProgressUpdateInterval = 30
+	}
+	if c.Message.AutoDelete == nil {
+		autoDelete := true
+		c.Message.AutoDelete = &autoDelete
+	}
+	if c.Auth.Enabled == nil {
+		enabled := true
+		c.Auth.Enabled = &enabled
+	}
+	if c.Aria2.RpcHost == "" {
+		c.Aria2.RpcHost = "127.0.0.1"
+	}
+	if c.Aria2.RpcPort == 0 {
+		c.Aria2.RpcPort = 6800
+	}
+	if c.Log.Level == "" {
+		c.Log.Level = "info"
+	}
+	if c.Log.MaxSize == 0 {
+		c.Log.MaxSize = 10
+	}
+	if c.Log.MaxBackups == 0 {
+		c.Log.MaxBackups = 7
+	}
+	if c.Log.MaxAge == 0 {
+		c.Log.MaxAge = 30
+	}
+	if c.Log.Dir == "" {
+		c.Log.Dir = "./logs"
+	}
+	if c.Aria2.InstallScriptURL == "" {
+		c.Aria2.InstallScriptURL = "https://git.io/aria2.sh"
+	}
+	if c.Aria2.InstallPath == "" {
+		c.Aria2.InstallPath = "/usr/local/bin"
+	}
+	if c.Aria2.ConfigDir == "" {
+		c.Aria2.ConfigDir = "/root/.aria2c"
+	}
+	if c.Aria2.DownloadDir == "" {
+		c.Aria2.DownloadDir = "/root/downloads"
+	}
+	if c.Aria2.SessionDir == "" {
+		c.Aria2.SessionDir = "/root/.aria2c"
+	}
+}
+
+// Save 将当前配置序列化为 YAML 写回文件。
+// 使用互斥锁防止并发写入竞态。
+func (c *Config) Save(path string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,14 @@ func (a *AuthConfig) IsEnabled() bool {
 	return *a.Enabled
 }
 
+// IsAutoDeleteEnabled 返回全局自动删除是否开启，默认启用。
+func (m *MessageConfig) IsAutoDeleteEnabled() bool {
+	if m.AutoDelete == nil {
+		return true
+	}
+	return *m.AutoDelete
+}
+
 // MessageConfig 消息行为配置，运行时可通过命令修改并持久化
 type MessageConfig struct {
 	AutoDelete              *bool `yaml:"auto_delete"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -165,6 +165,24 @@ bot:
 	}
 }
 
+// 测试：Auth.IsEnabled 显式设为 false
+func TestAuthConfig_IsEnabled_ExplicitFalse(t *testing.T) {
+	enabled := false
+	a := &AuthConfig{Enabled: &enabled}
+	if a.IsEnabled() {
+		t.Error("显式设为 false 时应返回 false")
+	}
+}
+
+// 测试：MessageConfig.IsAutoDeleteEnabled 显式设为 false
+func TestMessageConfig_IsAutoDeleteEnabled_ExplicitFalse(t *testing.T) {
+	autoDelete := false
+	m := &MessageConfig{AutoDelete: &autoDelete}
+	if m.IsAutoDeleteEnabled() {
+		t.Error("显式设为 false 时应返回 false")
+	}
+}
+
 // 测试：配置文件不存在时返回错误
 func TestLoad_FileNotFound(t *testing.T) {
 	_, err := Load("/nonexistent/path/config.yaml")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,186 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// 测试：加载有效的 YAML 配置文件
+func TestLoad_ValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `
+bot:
+  token: "test123:abc"
+  debug: true
+auth:
+  enabled: true
+  allow_users:
+    - 111
+    - 222
+message:
+  auto_delete: true
+  delete_after: 60
+  result_delete_after: 120
+  progress_update_interval: 15
+  install_log_delete: false
+  error_delete_after: 30
+  notify_delete_after: 60
+aria2:
+  install_script_url: "https://example.com/aria2.sh"
+  install_path: "/usr/bin"
+  config_dir: "/tmp/aria2"
+  download_dir: "/tmp/downloads"
+  rpc_host: "127.0.0.1"
+  rpc_port: 6800
+  rpc_secret: ""
+  session_dir: "/tmp/aria2"
+  auto_start: true
+  enable_systemd: true
+log:
+  dir: "/var/log/bot"
+  level: "debug"
+  max_size: 20
+  max_backups: 10
+  max_age: 60
+`
+	os.WriteFile(path, []byte(content), 0644)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("加载配置失败: %v", err)
+	}
+
+	if cfg.Bot.Token != "test123:abc" {
+		t.Errorf("Token 不匹配, got=%s", cfg.Bot.Token)
+	}
+	if !cfg.Bot.Debug {
+		t.Error("Debug 应为 true")
+	}
+	if !cfg.Auth.IsEnabled() {
+		t.Error("Auth.Enabled 应为 true")
+	}
+	if len(cfg.Auth.AllowUsers) != 2 {
+		t.Errorf("AllowUsers 长度应为 2, got=%d", len(cfg.Auth.AllowUsers))
+	}
+	if cfg.Aria2.RpcPort != 6800 {
+		t.Errorf("RpcPort 应为 6800, got=%d", cfg.Aria2.RpcPort)
+	}
+	if cfg.Log.Level != "debug" {
+		t.Errorf("Log.Level 应为 debug, got=%s", cfg.Log.Level)
+	}
+}
+
+// 测试：缺失字段自动填充默认值
+func TestSetDefaults_FillsMissingValues(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetDefaults()
+
+	if cfg.Bot.Debug != false {
+		t.Error("Debug 默认值应为 false")
+	}
+	if !cfg.Auth.IsEnabled() {
+		t.Error("Auth.Enabled 默认值应为 true")
+	}
+	if cfg.Message.AutoDelete == nil || *cfg.Message.AutoDelete != true {
+		t.Error("Message.AutoDelete 默认值应为 true")
+	}
+	if cfg.Message.DeleteAfter != 180 {
+		t.Errorf("Message.DeleteAfter 默认值应为 180, got=%d", cfg.Message.DeleteAfter)
+	}
+	if cfg.Message.ProgressUpdateInterval != 30 {
+		t.Errorf("ProgressUpdateInterval 默认值应为 30, got=%d", cfg.Message.ProgressUpdateInterval)
+	}
+	if cfg.Aria2.RpcHost != "127.0.0.1" {
+		t.Error("RpcHost 默认值应为 127.0.0.1")
+	}
+	if cfg.Aria2.RpcPort != 6800 {
+		t.Error("RpcPort 默认值应为 6800")
+	}
+	if cfg.Log.Level != "info" {
+		t.Errorf("Log.Level 默认值应为 info, got=%s", cfg.Log.Level)
+	}
+	if cfg.Log.MaxSize != 10 {
+		t.Errorf("Log.MaxSize 默认值应为 10, got=%d", cfg.Log.MaxSize)
+	}
+}
+
+// 测试：Token 支持从环境变量覆盖
+func TestLoad_TokenFromEnv(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `
+bot:
+  token: ""
+auth:
+  enabled: false
+`
+	os.WriteFile(path, []byte(content), 0644)
+	os.Setenv("BOT_TOKEN", "env_token_123")
+	defer os.Unsetenv("BOT_TOKEN")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("加载配置失败: %v", err)
+	}
+
+	if cfg.Bot.Token != "env_token_123" {
+		t.Errorf("Token 应从环境变量读取, got=%s", cfg.Bot.Token)
+	}
+}
+
+// 测试：配置持久化回写 + 重新读取一致
+func TestSaveAndReload_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `
+bot:
+  token: "original"
+`
+	os.WriteFile(path, []byte(content), 0644)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("加载配置失败: %v", err)
+	}
+
+	cfg.Bot.Token = "modified"
+	cfg.Bot.Debug = true
+
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("保存配置失败: %v", err)
+	}
+
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("重新加载配置失败: %v", err)
+	}
+
+	if reloaded.Bot.Token != "modified" {
+		t.Errorf("Token 应为 modified, got=%s", reloaded.Bot.Token)
+	}
+	if !reloaded.Bot.Debug {
+		t.Error("Debug 应为 true")
+	}
+}
+
+// 测试：配置文件不存在时返回错误
+func TestLoad_FileNotFound(t *testing.T) {
+	_, err := Load("/nonexistent/path/config.yaml")
+	if err == nil {
+		t.Error("不存在的文件应返回错误")
+	}
+}
+
+// 测试：无效 YAML 返回错误
+func TestLoad_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte("this: [is not valid yaml: {{{"), 0644)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Error("无效 YAML 应返回错误")
+	}
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -49,6 +49,7 @@ type Logger struct {
 }
 
 // New 创建 Logger 实例。日志目录不存在时自动创建。
+// MaxSize/MaxBackups/MaxAge 为 0 时采用 lumberjack 默认值（100MB/0/0），建议通过 config.SetDefaults() 设置合理值。
 func New(cfg Config) (*Logger, error) {
 	level := parseLevel(cfg.Level)
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,152 @@
+// Package logger 提供文本格式的结构化日志输出。
+// 支持 debug/info/warn/error 四个级别，自动记录调用位置（文件:行号:函数名）。
+// 基于 lumberjack 实现日志文件按大小轮转。
+package logger
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// Level 表示日志级别
+type Level int
+
+const (
+	DEBUG Level = iota
+	INFO
+	WARN
+	ERROR
+)
+
+var levelNames = map[Level]string{
+	DEBUG: "DEBUG",
+	INFO:  "INFO",
+	WARN:  "WARN",
+	ERROR: "ERROR",
+}
+
+// Config 日志配置
+type Config struct {
+	Dir        string // 日志文件目录
+	Level      string // debug / info / warn / error
+	MaxSize    int    // 单文件最大 MB
+	MaxBackups int    // 保留旧文件数
+	MaxAge     int    // 保留天数
+}
+
+// Logger 日志实例
+type Logger struct {
+	internal *log.Logger
+	level    Level
+	closer   io.Closer
+}
+
+// New 创建 Logger 实例。日志目录不存在时自动创建。
+func New(cfg Config) (*Logger, error) {
+	level := parseLevel(cfg.Level)
+
+	if err := os.MkdirAll(cfg.Dir, 0755); err != nil {
+		return nil, fmt.Errorf("创建日志目录 %s 失败: %w", cfg.Dir, err)
+	}
+
+	logPath := filepath.Join(cfg.Dir, "bot.log")
+	writer := &lumberjack.Logger{
+		Filename:   logPath,
+		MaxSize:    cfg.MaxSize,
+		MaxBackups: cfg.MaxBackups,
+		MaxAge:     cfg.MaxAge,
+		LocalTime:  true,
+	}
+
+	l := &Logger{
+		internal: log.New(writer, "", 0),
+		level:    level,
+		closer:   writer,
+	}
+
+	return l, nil
+}
+
+// Debug 输出调试级别日志
+func (l *Logger) Debug(format string, args ...interface{}) {
+	l.log(DEBUG, format, args...)
+}
+
+// Info 输出信息级别日志
+func (l *Logger) Info(format string, args ...interface{}) {
+	l.log(INFO, format, args...)
+}
+
+// Warn 输出警告级别日志
+func (l *Logger) Warn(format string, args ...interface{}) {
+	l.log(WARN, format, args...)
+}
+
+// Error 输出错误级别日志
+func (l *Logger) Error(format string, args ...interface{}) {
+	l.log(ERROR, format, args...)
+}
+
+// Close 关闭日志文件句柄
+func (l *Logger) Close() {
+	if l.closer != nil {
+		l.closer.Close()
+	}
+}
+
+// log 内部日志输出
+func (l *Logger) log(level Level, format string, args ...interface{}) {
+	if level < l.level {
+		return
+	}
+
+	msg := fmt.Sprintf(format, args...)
+
+	// 获取调用位置（跳过 2 帧：log → Debug/Info/Warn/Error → 调用者）
+	_, file, line, ok := runtime.Caller(2)
+	if !ok {
+		file = "???"
+		line = 0
+	}
+	// 仅保留文件名而非完整路径
+	if idx := strings.LastIndex(file, "/"); idx >= 0 {
+		file = file[idx+1:]
+	}
+
+	// 获取函数名
+	pc, _, _, _ := runtime.Caller(2)
+	funcName := "???"
+	if f := runtime.FuncForPC(pc); f != nil {
+		funcName = f.Name()
+		// 仅保留方法名，去掉包路径
+		if idx := strings.LastIndex(funcName, "."); idx >= 0 {
+			funcName = funcName[idx+1:]
+		}
+	}
+
+	// 格式: [LEVEL] [文件:行号:函数] 消息
+	l.internal.Printf("[%s] [%s:%d:%s] %s", levelNames[level], file, line, funcName, msg)
+}
+
+// parseLevel 将配置字符串转为 Level 常量
+func parseLevel(s string) Level {
+	switch strings.ToLower(s) {
+	case "debug":
+		return DEBUG
+	case "info":
+		return INFO
+	case "warn":
+		return WARN
+	case "error":
+		return ERROR
+	default:
+		return INFO
+	}
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -45,7 +45,7 @@ func TestLogger_LogLevels(t *testing.T) {
 	}
 }
 
-// 测试：日志级别过滤，debug 级别时不输出 debug 日志
+// 测试：日志级别过滤，info 级别时不输出 debug 日志
 func TestLogger_LevelFilter(t *testing.T) {
 	dir := t.TempDir()
 	log, err := New(Config{

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,128 @@
+package logger
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// 测试：各级别日志正常输出
+func TestLogger_LogLevels(t *testing.T) {
+	dir := t.TempDir()
+	log, err := New(Config{
+		Dir:        dir,
+		Level:      "debug",
+		MaxSize:    1,
+		MaxBackups: 1,
+		MaxAge:     1,
+	})
+	if err != nil {
+		t.Fatalf("创建 Logger 失败: %v", err)
+	}
+	defer log.Close()
+
+	log.Debug("调试信息")
+	log.Info("普通信息")
+	log.Warn("警告信息")
+	log.Error("错误信息")
+
+	// 读取日志文件验证各条消息存在
+	files, _ := filepath.Glob(filepath.Join(dir, "*.log"))
+	if len(files) == 0 {
+		t.Fatal("未生成日志文件")
+	}
+
+	content, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatalf("读取日志文件失败: %v", err)
+	}
+	s := string(content)
+	for _, expected := range []string{"[DEBUG]", "调试信息", "[INFO]", "普通信息", "[WARN]", "警告信息", "[ERROR]", "错误信息"} {
+		if !strings.Contains(s, expected) {
+			t.Errorf("日志应包含 %q, content=%s", expected, s)
+		}
+	}
+}
+
+// 测试：日志级别过滤，debug 级别时不输出 debug 日志
+func TestLogger_LevelFilter(t *testing.T) {
+	dir := t.TempDir()
+	log, err := New(Config{
+		Dir:        dir,
+		Level:      "info",
+		MaxSize:    1,
+		MaxBackups: 1,
+		MaxAge:     1,
+	})
+	if err != nil {
+		t.Fatalf("创建 Logger 失败: %v", err)
+	}
+	defer log.Close()
+
+	log.Debug("这条不应出现")
+	log.Info("这条应出现")
+
+	files, _ := filepath.Glob(filepath.Join(dir, "*.log"))
+	if len(files) == 0 {
+		t.Fatal("未生成日志文件")
+	}
+	content, _ := os.ReadFile(files[0])
+	s := string(content)
+	if strings.Contains(s, "这条不应出现") {
+		t.Error("debug 级别日志应被过滤")
+	}
+	if !strings.Contains(s, "这条应出现") {
+		t.Error("info 级别日志应出现")
+	}
+}
+
+// 测试：日志包含调用位置信息
+func TestLogger_CallerInfo(t *testing.T) {
+	dir := t.TempDir()
+	log, err := New(Config{
+		Dir:        dir,
+		Level:      "debug",
+		MaxSize:    1,
+		MaxBackups: 1,
+		MaxAge:     1,
+	})
+	if err != nil {
+		t.Fatalf("创建 Logger 失败: %v", err)
+	}
+	defer log.Close()
+
+	log.Info("定位测试")
+
+	files, _ := filepath.Glob(filepath.Join(dir, "*.log"))
+	content, _ := os.ReadFile(files[0])
+	s := string(content)
+
+	// 断言日志包含调用位置（logger_test.go:行号:TestLogger_CallerInfo）
+	if !strings.Contains(s, "logger_test.go") {
+		t.Errorf("日志应包含调用文件信息, content=%s", s)
+	}
+}
+
+// 测试：日志目录不存在时自动创建
+func TestLogger_AutoCreateDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "new-subdir", "logs")
+	log, err := New(Config{
+		Dir:        dir,
+		Level:      "info",
+		MaxSize:    1,
+		MaxBackups: 1,
+		MaxAge:     1,
+	})
+	if err != nil {
+		t.Fatalf("自动创建目录时应成功: %v", err)
+	}
+	defer log.Close()
+
+	log.Info("目录已创建")
+
+	files, _ := filepath.Glob(filepath.Join(dir, "*.log"))
+	if len(files) == 0 {
+		t.Fatal("日志目录应被自动创建并写入文件")
+	}
+}


### PR DESCRIPTION
搭建 Go 项目骨架：go.mod、Makefile、配置层、日志层、入口。
- config 包：YAML 加载/默认值/校验/持久化 (6 测试)
- logger 包：文本日志 + 级别过滤 + 调用位置 + 轮转 (4 测试)
- cmd/bot/main.go：启动流程 (加载配置 → 日志 → 信号等待)
- 提供默认 config.yaml 模板和 systemd unit 文件