### PR TITLE
feat: Keyboard 回调与消息管理 — Issue #4

### DIFF
--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -33,7 +33,8 @@ func New(svc any, cfg *config.Config, log *logger.Logger) (*Bot, error) {
 		stopCh: make(chan struct{}),
 	}
 
-	bot.handler = NewHandler(svc, cfg, api, log)
+	msgMgr := NewMessageManager(api, cfg)
+	bot.handler = NewHandler(svc, cfg, api, log, msgMgr)
 	return bot, nil
 }
 

--- a/internal/telegram/callback.go
+++ b/internal/telegram/callback.go
@@ -1,6 +1,11 @@
 package telegram
 
-import tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+import (
+	"strconv"
+	"strings"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
 
 // 回调数据前缀常量。
 const (
@@ -14,12 +19,143 @@ const (
 	CbRefresh    = "refresh"     // refresh:active / refresh:done
 )
 
-// HandleCallback 处理 Inline Keyboard 回调查询（占位实现）。
-// 后续 Issue #4 完成完整的回调分发逻辑。
+// 确认/取消操作的合法 action 白名单。
+var validActions = map[string]bool{
+	"install":      true,
+	"uninstall":    true,
+	"reset_secret": true,
+}
+
+// HandleCallback 处理 Inline Keyboard 回调查询。
 func (h *Handler) HandleCallback(query *tgbotapi.CallbackQuery) {
-	// 占位：回复空回调确认，避免客户端一直显示 loading
+	// 立即回复空回调确认，消除客户端 loading
 	callback := tgbotapi.NewCallback(query.ID, "")
 	if _, err := h.bot.Request(callback); err != nil {
 		h.logger.Error("回调确认失败: %v", err)
 	}
+
+	prefix, rest := parseCallbackData(query.Data)
+	if prefix == "" && rest == "" {
+		return // 空 data 或解析失败
+	}
+
+	switch prefix {
+	case CbConfirm:
+		h.handleConfirmCallback(query, rest)
+	case CbCancel:
+		h.handleCancelCallback(query, rest)
+	case CbPause:
+		h.handlePauseCallback(query, rest)
+	case CbResume:
+		h.handleResumeCallback(query, rest)
+	case CbRemove:
+		h.handleRemoveCallback(query, rest)
+	case CbRemoveDone:
+		h.handleRemoveDoneCallback(query, rest)
+	case CbPage:
+		h.handlePageCallback(query, rest)
+	case CbRefresh:
+		h.handleRefreshCallback(query, rest)
+	default:
+		h.logger.Debug("未知回调前缀: %s", prefix)
+	}
+}
+
+// handleConfirmCallback 处理确认回调。rest = "<action>"
+func (h *Handler) handleConfirmCallback(query *tgbotapi.CallbackQuery, action string) {
+	if !validActions[action] {
+		h.logger.Debug("无效确认 action: %s", action)
+		return
+	}
+	chatID := query.Message.Chat.ID
+	h.msgMgr.Send(chatID, "确认操作: "+action+" — 该功能将在后续版本实现", LabelCommand)
+}
+
+// handleCancelCallback 处理取消回调。rest = "<action>"
+func (h *Handler) handleCancelCallback(query *tgbotapi.CallbackQuery, action string) {
+	if !validActions[action] {
+		h.logger.Debug("无效取消 action: %s", action)
+		return
+	}
+	chatID := query.Message.Chat.ID
+	h.msgMgr.Send(chatID, "已取消操作: "+action, LabelCommand)
+}
+
+// handlePauseCallback 处理暂停回调。rest = "<gid>"
+func (h *Handler) handlePauseCallback(query *tgbotapi.CallbackQuery, gid string) {
+	if gid == "" {
+		return
+	}
+	chatID := query.Message.Chat.ID
+	h.logger.Debug("暂停任务: gid=%s, chatID=%d", gid, chatID)
+	h.msgMgr.Send(chatID, "该功能将在后续版本实现", LabelCommand)
+}
+
+// handleResumeCallback 处理恢复回调。rest = "<gid>"
+func (h *Handler) handleResumeCallback(query *tgbotapi.CallbackQuery, gid string) {
+	if gid == "" {
+		return
+	}
+	chatID := query.Message.Chat.ID
+	h.logger.Debug("恢复任务: gid=%s, chatID=%d", gid, chatID)
+	h.msgMgr.Send(chatID, "该功能将在后续版本实现", LabelCommand)
+}
+
+// handleRemoveCallback 处理删除回调。rest = "<gid>"
+func (h *Handler) handleRemoveCallback(query *tgbotapi.CallbackQuery, gid string) {
+	if gid == "" {
+		return
+	}
+	chatID := query.Message.Chat.ID
+	h.logger.Debug("删除任务: gid=%s, chatID=%d", gid, chatID)
+	h.msgMgr.Send(chatID, "该功能将在后续版本实现", LabelCommand)
+}
+
+// handleRemoveDoneCallback 处理已完成记录删除回调。rest = "<gid>"
+func (h *Handler) handleRemoveDoneCallback(query *tgbotapi.CallbackQuery, gid string) {
+	if gid == "" {
+		return
+	}
+	chatID := query.Message.Chat.ID
+	h.logger.Debug("删除记录: gid=%s, chatID=%d", gid, chatID)
+	h.msgMgr.Send(chatID, "该功能将在后续版本实现", LabelCommand)
+}
+
+// handlePageCallback 处理分页回调。rest = "<type>:<page>"
+func (h *Handler) handlePageCallback(query *tgbotapi.CallbackQuery, rest string) {
+	parts := strings.SplitN(rest, ":", 2)
+	listType := parts[0]
+	page := 1
+	if len(parts) > 1 {
+		if n, err := strconv.Atoi(parts[1]); err == nil {
+			page = n
+		}
+	}
+	chatID := query.Message.Chat.ID
+	h.logger.Debug("翻页: type=%s, page=%d, chatID=%d", listType, page, chatID)
+	h.msgMgr.Send(chatID, "该功能将在后续版本实现", LabelCommand)
+}
+
+// handleRefreshCallback 处理刷新回调。rest = "<type>"
+func (h *Handler) handleRefreshCallback(query *tgbotapi.CallbackQuery, listType string) {
+	chatID := query.Message.Chat.ID
+	h.logger.Debug("刷新列表: type=%s, chatID=%d", listType, chatID)
+	h.msgMgr.Send(chatID, "该功能将在后续版本实现", LabelCommand)
+}
+
+// parseCallbackData 解析回调数据字符串，返回前缀和剩余参数。
+// "pause:abc123" → "pause", "abc123"
+// "page:active:2" → "page", "active:2"
+// "" → "", ""
+// "invalid" → "invalid", ""
+func parseCallbackData(data string) (prefix, rest string) {
+	if data == "" {
+		return "", ""
+	}
+	parts := strings.SplitN(data, ":", 2)
+	prefix = parts[0]
+	if len(parts) > 1 {
+		rest = parts[1]
+	}
+	return
 }

--- a/internal/telegram/callback_test.go
+++ b/internal/telegram/callback_test.go
@@ -1,0 +1,144 @@
+package telegram
+
+import (
+	"testing"
+)
+
+func TestParseCallbackData_Pause(t *testing.T) {
+	prefix, rest := parseCallbackData("pause:abc123")
+	if prefix != "pause" {
+		t.Errorf("prefix 应为 'pause', 实际 %q", prefix)
+	}
+	if rest != "abc123" {
+		t.Errorf("rest 应为 'abc123', 实际 %q", rest)
+	}
+}
+
+func TestParseCallbackData_Resume(t *testing.T) {
+	prefix, rest := parseCallbackData("resume:xyz789")
+	if prefix != "resume" {
+		t.Errorf("prefix 应为 'resume', 实际 %q", prefix)
+	}
+	if rest != "xyz789" {
+		t.Errorf("rest 应为 'xyz789', 实际 %q", rest)
+	}
+}
+
+func TestParseCallbackData_Remove(t *testing.T) {
+	prefix, rest := parseCallbackData("remove:gid123")
+	if prefix != "remove" {
+		t.Errorf("prefix 应为 'remove', 实际 %q", prefix)
+	}
+	if rest != "gid123" {
+		t.Errorf("rest 应为 'gid123', 实际 %q", rest)
+	}
+}
+
+func TestParseCallbackData_RemoveDone(t *testing.T) {
+	prefix, rest := parseCallbackData("remove_done:gid456")
+	if prefix != "remove_done" {
+		t.Errorf("prefix 应为 'remove_done', 实际 %q", prefix)
+	}
+	if rest != "gid456" {
+		t.Errorf("rest 应为 'gid456', 实际 %q", rest)
+	}
+}
+
+func TestParseCallbackData_Page(t *testing.T) {
+	prefix, rest := parseCallbackData("page:active:2")
+	if prefix != "page" {
+		t.Errorf("prefix 应为 'page', 实际 %q", prefix)
+	}
+	if rest != "active:2" {
+		t.Errorf("rest 应为 'active:2', 实际 %q", rest)
+	}
+}
+
+func TestParseCallbackData_Refresh(t *testing.T) {
+	prefix, rest := parseCallbackData("refresh:active")
+	if prefix != "refresh" {
+		t.Errorf("prefix 应为 'refresh', 实际 %q", prefix)
+	}
+	if rest != "active" {
+		t.Errorf("rest 应为 'active', 实际 %q", rest)
+	}
+}
+
+func TestParseCallbackData_Confirm(t *testing.T) {
+	prefix, rest := parseCallbackData("confirm:install")
+	if prefix != "confirm" {
+		t.Errorf("prefix 应为 'confirm', 实际 %q", prefix)
+	}
+	if rest != "install" {
+		t.Errorf("rest 应为 'install', 实际 %q", rest)
+	}
+}
+
+func TestParseCallbackData_Cancel(t *testing.T) {
+	prefix, rest := parseCallbackData("cancel:uninstall")
+	if prefix != "cancel" {
+		t.Errorf("prefix 应为 'cancel', 实际 %q", prefix)
+	}
+	if rest != "uninstall" {
+		t.Errorf("rest 应为 'uninstall', 实际 %q", rest)
+	}
+}
+
+func TestParseCallbackData_EmptyData(t *testing.T) {
+	prefix, rest := parseCallbackData("")
+	if prefix != "" {
+		t.Errorf("空 data 的 prefix 应为 '', 实际 %q", prefix)
+	}
+	if rest != "" {
+		t.Errorf("空 data 的 rest 应为 '', 实际 %q", rest)
+	}
+}
+
+func TestParseCallbackData_NoSeparator(t *testing.T) {
+	prefix, rest := parseCallbackData("invalidformat")
+	if prefix != "invalidformat" {
+		t.Errorf("prefix 应为 'invalidformat', 实际 %q", prefix)
+	}
+	if rest != "" {
+		t.Errorf("rest 应为 '', 实际 %q", rest)
+	}
+}
+
+func TestParseCallbackData_UnknownPrefix(t *testing.T) {
+	prefix, rest := parseCallbackData("unknown:somearg")
+	if prefix != "unknown" {
+		t.Errorf("prefix 应为 'unknown', 实际 %q", prefix)
+	}
+	if rest != "somearg" {
+		t.Errorf("rest 应为 'somearg', 实际 %q", rest)
+	}
+}
+
+func TestParseCallbackData_GidWithSpecialChars(t *testing.T) {
+	// aria2 GID 是 16 进制字符串，应完整传递
+	prefix, rest := parseCallbackData("pause:b469d2d63f9a8b3e")
+	if prefix != "pause" {
+		t.Errorf("prefix 应为 'pause', 实际 %q", prefix)
+	}
+	if rest != "b469d2d63f9a8b3e" {
+		t.Errorf("rest 应为完整 GID, 实际 %q", rest)
+	}
+}
+
+func TestValidActions(t *testing.T) {
+	if !validActions["install"] {
+		t.Error("install 应在白名单中")
+	}
+	if !validActions["uninstall"] {
+		t.Error("uninstall 应在白名单中")
+	}
+	if !validActions["reset_secret"] {
+		t.Error("reset_secret 应在白名单中")
+	}
+	if validActions["unknown"] {
+		t.Error("unknown 不应在白名单中")
+	}
+	if validActions[""] {
+		t.Error("空字符串不应在白名单中")
+	}
+}

--- a/internal/telegram/command.go
+++ b/internal/telegram/command.go
@@ -305,149 +305,149 @@ func (h *Handler) RegisterCommands() map[string]*Command {
 // ===== 帮助 & 状态命令处理（占位） =====
 
 func (h *Handler) handleHelp(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handlePing(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "pong!")
+	h.msgMgr.Send(msg.Chat.ID, "pong!", LabelCommand)
 }
 
 func (h *Handler) handleHealth(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 // ===== 安装管理命令处理（占位） =====
 
 func (h *Handler) handleInstall(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleUninstall(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleUpgrade(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 // ===== 进程管理命令处理（占位） =====
 
 func (h *Handler) handleAriaStart(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleAriaStop(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleAriaRestart(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleAriaStatus(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 // ===== 下载操作命令处理（占位） =====
 
 func (h *Handler) handleAdd(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleAddMagnet(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handlePause(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleResume(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleRemove(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 // ===== 列表查询命令处理（占位） =====
 
 func (h *Handler) handleList(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleDone(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleClear(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 // ===== 速度控制命令处理（占位） =====
 
 func (h *Handler) handleLimitGlobal(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleLimitTask(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 // ===== Aria2 配置命令处理（占位） =====
 
 func (h *Handler) handleConf(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleConfDir(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleConfRpcPort(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleConfSecret(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleResetSecret(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 // ===== 统计命令处理（占位） =====
 
 func (h *Handler) handleStats(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 // ===== 消息行为命令处理（占位） =====
 
 func (h *Handler) handleMsgConfig(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleMsgAutodel(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleMsgTime(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleMsgResult(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleMsgError(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleMsgNotify(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }
 
 func (h *Handler) handleMsgProgress(msg *tgbotapi.Message, args []string) {
-	h.sendReply(msg.Chat.ID, "该功能将在后续版本实现")
+	h.msgMgr.Send(msg.Chat.ID, "该功能将在后续版本实现", LabelCommand)
 }

--- a/internal/telegram/handler.go
+++ b/internal/telegram/handler.go
@@ -85,14 +85,6 @@ func (h *Handler) authorize(userID int64) bool {
 	return Authorize(h.cfg, userID)
 }
 
-// sendReply 发送纯文本回复消息（占位实现，后续 #4 替换为 MessageManager.Send）。
-func (h *Handler) sendReply(chatID int64, text string) {
-	msg := tgbotapi.NewMessage(chatID, text)
-	if _, err := h.bot.Send(msg); err != nil {
-		h.logger.Error("发送消息失败 (chatID: %d): %v", chatID, err)
-	}
-}
-
 // parseCommand 从消息文本中解析命令名和参数。
 // "/add http://example.com" → "/add", ["http://example.com"]
 // "/help" → "/help", []

--- a/internal/telegram/handler.go
+++ b/internal/telegram/handler.go
@@ -17,18 +17,20 @@ type Handler struct {
 	bot    *tgbotapi.BotAPI
 	logger *logger.Logger
 
+	msgMgr   *MessageManager              // 消息管理器
 	commands map[string]*Command           // 命令注册表
 	gidMap   map[int64]map[int]string     // chatID -> 编号 -> GID（待 #5 添加访问方法）
 }
 
 // NewHandler 创建 Handler 实例。
 // svc 参数当前为占位接口，后续 Issue #5 完成后注入真实 service.Container。
-func NewHandler(svc any, cfg *config.Config, bot *tgbotapi.BotAPI, log *logger.Logger) *Handler {
+func NewHandler(svc any, cfg *config.Config, bot *tgbotapi.BotAPI, log *logger.Logger, msgMgr *MessageManager) *Handler {
 	h := &Handler{
 		svc:    svc,
 		cfg:    cfg,
 		bot:    bot,
 		logger: log,
+		msgMgr: msgMgr,
 		gidMap: make(map[int64]map[int]string),
 	}
 	h.commands = h.RegisterCommands()

--- a/internal/telegram/keyboard.go
+++ b/internal/telegram/keyboard.go
@@ -1,0 +1,109 @@
+package telegram
+
+import tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+
+// BuildConfirmKeyboard 构建确认/取消 Inline 键盘。
+// action 取值: "install", "uninstall", "reset_secret"
+func BuildConfirmKeyboard(action string) tgbotapi.InlineKeyboardMarkup {
+	return tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData("确认", CbConfirm+":"+action),
+			tgbotapi.NewInlineKeyboardButtonData("取消", CbCancel+":"+action),
+		),
+	)
+}
+
+// BuildTaskKeyboard 构建活动任务操作 Inline 键盘。
+// isPaused=true 时显示[恢复]，否则显示[暂停]；始终显示[删除]。
+func BuildTaskKeyboard(gid string, isPaused bool) tgbotapi.InlineKeyboardMarkup {
+	var actionBtn tgbotapi.InlineKeyboardButton
+	if isPaused {
+		actionBtn = tgbotapi.NewInlineKeyboardButtonData("恢复", CbResume+":"+gid)
+	} else {
+		actionBtn = tgbotapi.NewInlineKeyboardButtonData("暂停", CbPause+":"+gid)
+	}
+	return tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			actionBtn,
+			tgbotapi.NewInlineKeyboardButtonData("删除", CbRemove+":"+gid),
+		),
+	)
+}
+
+// BuildDoneTaskKeyboard 构建已完成任务操作 Inline 键盘（仅删除记录按钮）。
+func BuildDoneTaskKeyboard(gid string) tgbotapi.InlineKeyboardMarkup {
+	return tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData("删除记录", CbRemoveDone+":"+gid),
+		),
+	)
+}
+
+// BuildPaginationKeyboard 构建分页导航 Inline 键盘。
+// page=1 时隐藏[上一页]，page=total 时隐藏[下一页]，total<=1 时仅显示[刷新]。
+func BuildPaginationKeyboard(listType string, page, total int) tgbotapi.InlineKeyboardMarkup {
+	var row []tgbotapi.InlineKeyboardButton
+
+	if page > 1 {
+		row = append(row, tgbotapi.NewInlineKeyboardButtonData(
+			"上一页", CbPage+":"+listType+":"+itoa(page-1),
+		))
+	}
+	if page < total {
+		row = append(row, tgbotapi.NewInlineKeyboardButtonData(
+			"下一页", CbPage+":"+listType+":"+itoa(page+1),
+		))
+	}
+	row = append(row, tgbotapi.NewInlineKeyboardButtonData(
+		"刷新", CbRefresh+":"+listType,
+	))
+
+	return tgbotapi.NewInlineKeyboardMarkup(row)
+}
+
+// itoa 是 fmt.Sprintf("%d", n) 的轻量替代，避免导入 fmt。
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte(n%10) + '0'
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// BuildMainKeyboard 构建默认 Reply 键盘（已安装 aria2 时使用）。
+func BuildMainKeyboard() tgbotapi.ReplyKeyboardMarkup {
+	return tgbotapi.NewReplyKeyboard(
+		tgbotapi.NewKeyboardButtonRow(
+			tgbotapi.NewKeyboardButton("列表"),
+			tgbotapi.NewKeyboardButton("状态"),
+		),
+		tgbotapi.NewKeyboardButtonRow(
+			tgbotapi.NewKeyboardButton("统计"),
+			tgbotapi.NewKeyboardButton("帮助"),
+		),
+	)
+}
+
+// BuildPreInstallKeyboard 构建预安装 Reply 键盘（未安装 aria2 时使用）。
+func BuildPreInstallKeyboard() tgbotapi.ReplyKeyboardMarkup {
+	return tgbotapi.NewReplyKeyboard(
+		tgbotapi.NewKeyboardButtonRow(
+			tgbotapi.NewKeyboardButton("安装 Aria2"),
+			tgbotapi.NewKeyboardButton("帮助"),
+		),
+	)
+}

--- a/internal/telegram/keyboard_test.go
+++ b/internal/telegram/keyboard_test.go
@@ -1,0 +1,265 @@
+package telegram
+
+import (
+	"testing"
+)
+
+// ===== BuildConfirmKeyboard 测试 =====
+
+func TestBuildConfirmKeyboard_ButtonsAndData(t *testing.T) {
+	kb := BuildConfirmKeyboard("install")
+	if len(kb.InlineKeyboard) != 1 {
+		t.Fatalf("期望 1 行, 实际 %d 行", len(kb.InlineKeyboard))
+	}
+	row := kb.InlineKeyboard[0]
+	if len(row) != 2 {
+		t.Fatalf("期望 2 个按钮, 实际 %d", len(row))
+	}
+	if row[0].Text != "确认" {
+		t.Errorf("按钮0 文本应为 '确认', 实际 %q", row[0].Text)
+	}
+	if *row[0].CallbackData != "confirm:install" {
+		t.Errorf("按钮0 data 应为 'confirm:install', 实际 %q", *row[0].CallbackData)
+	}
+	if row[1].Text != "取消" {
+		t.Errorf("按钮1 文本应为 '取消', 实际 %q", row[1].Text)
+	}
+	if *row[1].CallbackData != "cancel:install" {
+		t.Errorf("按钮1 data 应为 'cancel:install', 实际 %q", *row[1].CallbackData)
+	}
+}
+
+// ===== BuildTaskKeyboard 测试 =====
+
+func TestBuildTaskKeyboard_Running(t *testing.T) {
+	kb := BuildTaskKeyboard("abc123", false)
+	row := kb.InlineKeyboard[0]
+	if len(row) != 2 {
+		t.Fatalf("期望 2 个按钮, 实际 %d", len(row))
+	}
+	if row[0].Text != "暂停" {
+		t.Errorf("运行中任务应显示 '暂停', 实际 %q", row[0].Text)
+	}
+	if *row[0].CallbackData != "pause:abc123" {
+		t.Errorf("data 应为 'pause:abc123', 实际 %q", *row[0].CallbackData)
+	}
+	if row[1].Text != "删除" {
+		t.Errorf("按钮1 文本应为 '删除', 实际 %q", row[1].Text)
+	}
+	if *row[1].CallbackData != "remove:abc123" {
+		t.Errorf("data 应为 'remove:abc123', 实际 %q", *row[1].CallbackData)
+	}
+}
+
+func TestBuildTaskKeyboard_Paused(t *testing.T) {
+	kb := BuildTaskKeyboard("xyz789", true)
+	row := kb.InlineKeyboard[0]
+	if len(row) != 2 {
+		t.Fatalf("期望 2 个按钮, 实际 %d", len(row))
+	}
+	if row[0].Text != "恢复" {
+		t.Errorf("暂停任务应显示 '恢复', 实际 %q", row[0].Text)
+	}
+	if *row[0].CallbackData != "resume:xyz789" {
+		t.Errorf("data 应为 'resume:xyz789', 实际 %q", *row[0].CallbackData)
+	}
+}
+
+// ===== BuildDoneTaskKeyboard 测试 =====
+
+func TestBuildDoneTaskKeyboard(t *testing.T) {
+	kb := BuildDoneTaskKeyboard("done123")
+	row := kb.InlineKeyboard[0]
+	if len(row) != 1 {
+		t.Fatalf("期望 1 个按钮, 实际 %d", len(row))
+	}
+	if row[0].Text != "删除记录" {
+		t.Errorf("文本应为 '删除记录', 实际 %q", row[0].Text)
+	}
+	if *row[0].CallbackData != "remove_done:done123" {
+		t.Errorf("data 应为 'remove_done:done123', 实际 %q", *row[0].CallbackData)
+	}
+}
+
+// ===== BuildPaginationKeyboard 测试 =====
+
+func TestBuildPaginationKeyboard_FirstPage(t *testing.T) {
+	kb := BuildPaginationKeyboard("active", 1, 5)
+	row := kb.InlineKeyboard[0]
+	// 第一页：无[上一页]，有[下一页][刷新]
+	if len(row) != 2 {
+		t.Fatalf("第一页期望 2 个按钮, 实际 %d", len(row))
+	}
+	if row[0].Text != "下一页" {
+		t.Errorf("按钮0 应为 '下一页', 实际 %q", row[0].Text)
+	}
+	if *row[0].CallbackData != "page:active:2" {
+		t.Errorf("data 应为 'page:active:2', 实际 %q", *row[0].CallbackData)
+	}
+	if row[1].Text != "刷新" {
+		t.Errorf("按钮1 应为 '刷新', 实际 %q", row[1].Text)
+	}
+}
+
+func TestBuildPaginationKeyboard_LastPage(t *testing.T) {
+	kb := BuildPaginationKeyboard("active", 5, 5)
+	row := kb.InlineKeyboard[0]
+	// 最后一页：有[上一页]，无[下一页]
+	if len(row) != 2 {
+		t.Fatalf("最后一页期望 2 个按钮, 实际 %d", len(row))
+	}
+	if row[0].Text != "上一页" {
+		t.Errorf("按钮0 应为 '上一页', 实际 %q", row[0].Text)
+	}
+	if *row[0].CallbackData != "page:active:4" {
+		t.Errorf("data 应为 'page:active:4', 实际 %q", *row[0].CallbackData)
+	}
+}
+
+func TestBuildPaginationKeyboard_MiddlePage(t *testing.T) {
+	kb := BuildPaginationKeyboard("done", 3, 5)
+	row := kb.InlineKeyboard[0]
+	// 中间页：三个按钮齐全
+	if len(row) != 3 {
+		t.Fatalf("中间页期望 3 个按钮, 实际 %d", len(row))
+	}
+	if row[0].Text != "上一页" {
+		t.Errorf("按钮0 应为 '上一页', 实际 %q", row[0].Text)
+	}
+	if row[1].Text != "下一页" {
+		t.Errorf("按钮1 应为 '下一页', 实际 %q", row[1].Text)
+	}
+	if row[2].Text != "刷新" {
+		t.Errorf("按钮2 应为 '刷新', 实际 %q", row[2].Text)
+	}
+}
+
+func TestBuildPaginationKeyboard_SinglePage(t *testing.T) {
+	kb := BuildPaginationKeyboard("active", 1, 1)
+	row := kb.InlineKeyboard[0]
+	// total=1: 仅[刷新]
+	if len(row) != 1 {
+		t.Fatalf("单页期望 1 个按钮, 实际 %d", len(row))
+	}
+	if row[0].Text != "刷新" {
+		t.Errorf("按钮应为 '刷新', 实际 %q", row[0].Text)
+	}
+}
+
+func TestBuildPaginationKeyboard_ZeroTotal(t *testing.T) {
+	kb := BuildPaginationKeyboard("active", 0, 0)
+	row := kb.InlineKeyboard[0]
+	// total=0: 仅[刷新]
+	if len(row) != 1 {
+		t.Fatalf("零条目期望 1 个按钮, 实际 %d", len(row))
+	}
+	if row[0].Text != "刷新" {
+		t.Errorf("按钮应为 '刷新', 实际 %q", row[0].Text)
+	}
+}
+
+func TestBuildPaginationKeyboard_DifferentListTypes(t *testing.T) {
+	// 验证 listType 正确传入 callback data
+	kb := BuildPaginationKeyboard("done", 2, 5)
+	row := kb.InlineKeyboard[0]
+	// 第2页共5页: [上一页][下一页][刷新]
+	if *row[0].CallbackData != "page:done:1" {
+		t.Errorf("上一页 data 应为 'page:done:1', 实际 %q", *row[0].CallbackData)
+	}
+	if *row[1].CallbackData != "page:done:3" {
+		t.Errorf("下一页 data 应为 'page:done:3', 实际 %q", *row[1].CallbackData)
+	}
+	if *row[2].CallbackData != "refresh:done" {
+		t.Errorf("刷新 data 应为 'refresh:done', 实际 %q", *row[2].CallbackData)
+	}
+}
+
+// ===== BuildMainKeyboard 测试 =====
+
+func TestBuildMainKeyboard(t *testing.T) {
+	kb := BuildMainKeyboard()
+	if len(kb.Keyboard) != 2 {
+		t.Fatalf("期望 2 行, 实际 %d", len(kb.Keyboard))
+	}
+	if len(kb.Keyboard[0]) != 2 || len(kb.Keyboard[1]) != 2 {
+		t.Fatal("每行应有 2 个按钮")
+	}
+	// 验证按钮文本
+	texts := []string{
+		kb.Keyboard[0][0].Text, kb.Keyboard[0][1].Text,
+		kb.Keyboard[1][0].Text, kb.Keyboard[1][1].Text,
+	}
+	expected := []string{"列表", "状态", "统计", "帮助"}
+	for i, txt := range texts {
+		if txt != expected[i] {
+			t.Errorf("按钮 %d: 期望 %q, 实际 %q", i, expected[i], txt)
+		}
+	}
+	if !kb.ResizeKeyboard {
+		t.Error("ResizeKeyboard 应为 true")
+	}
+}
+
+// ===== BuildPreInstallKeyboard 测试 =====
+
+func TestBuildPreInstallKeyboard(t *testing.T) {
+	kb := BuildPreInstallKeyboard()
+	if len(kb.Keyboard) != 1 {
+		t.Fatalf("期望 1 行, 实际 %d", len(kb.Keyboard))
+	}
+	if len(kb.Keyboard[0]) != 2 {
+		t.Fatalf("期望 2 个按钮, 实际 %d", len(kb.Keyboard[0]))
+	}
+	if kb.Keyboard[0][0].Text != "安装 Aria2" {
+		t.Errorf("按钮0 应为 '安装 Aria2', 实际 %q", kb.Keyboard[0][0].Text)
+	}
+	if kb.Keyboard[0][1].Text != "帮助" {
+		t.Errorf("按钮1 应为 '帮助', 实际 %q", kb.Keyboard[0][1].Text)
+	}
+	if !kb.ResizeKeyboard {
+		t.Error("ResizeKeyboard 应为 true")
+	}
+}
+
+// ===== itoa 辅助函数测试 =====
+
+func TestItoa(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{-1, "-1"},
+		{10, "10"},
+		{100, "100"},
+		{-50, "-50"},
+		{999, "999"},
+	}
+	for _, tc := range tests {
+		got := itoa(tc.n)
+		if got != tc.want {
+			t.Errorf("itoa(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}
+
+// ===== Benchmark =====
+
+func BenchmarkBuildConfirmKeyboard(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		BuildConfirmKeyboard("install")
+	}
+}
+
+func BenchmarkBuildPaginationKeyboard(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		BuildPaginationKeyboard("active", 5, 20)
+	}
+}
+
+func BenchmarkBuildTaskKeyboard(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		BuildTaskKeyboard("abc123def456", false)
+	}
+}

--- a/internal/telegram/keyboard_test.go
+++ b/internal/telegram/keyboard_test.go
@@ -63,6 +63,12 @@ func TestBuildTaskKeyboard_Paused(t *testing.T) {
 	if *row[0].CallbackData != "resume:xyz789" {
 		t.Errorf("data 应为 'resume:xyz789', 实际 %q", *row[0].CallbackData)
 	}
+	if row[1].Text != "删除" {
+		t.Errorf("按钮1 文本应为 '删除', 实际 %q", row[1].Text)
+	}
+	if *row[1].CallbackData != "remove:xyz789" {
+		t.Errorf("data 应为 'remove:xyz789', 实际 %q", *row[1].CallbackData)
+	}
 }
 
 // ===== BuildDoneTaskKeyboard 测试 =====

--- a/internal/telegram/message.go
+++ b/internal/telegram/message.go
@@ -1,0 +1,206 @@
+package telegram
+
+import (
+	"sync"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+
+	"github.com/dnslin/aria2-tgbot/internal/config"
+)
+
+// MessageLabel 消息类型标签，用于 getTTL 查表获取对应的自动删除时间。
+type MessageLabel string
+
+const (
+	LabelCommand  MessageLabel = "command"
+	LabelProgress MessageLabel = "progress"
+	LabelInstall  MessageLabel = "install"
+	LabelError    MessageLabel = "error"
+	LabelNotify   MessageLabel = "notify"
+)
+
+// sendConfig 内部配置结构体，由 SendOption 函数选项填充。
+type sendConfig struct {
+	inlineKeyboard *tgbotapi.InlineKeyboardMarkup
+	replyKeyboard  interface{} // tgbotapi.ReplyKeyboardMarkup 或 ReplyKeyboardRemove
+}
+
+// SendOption 消息发送函数选项。
+type SendOption func(*sendConfig)
+
+// WithInlineKeyboard 为消息附加 Inline 键盘。
+func WithInlineKeyboard(kb tgbotapi.InlineKeyboardMarkup) SendOption {
+	return func(sc *sendConfig) {
+		sc.inlineKeyboard = &kb
+	}
+}
+
+// WithReplyKeyboard 为消息附加 Reply 键盘。
+func WithReplyKeyboard(kb tgbotapi.ReplyKeyboardMarkup) SendOption {
+	return func(sc *sendConfig) {
+		sc.replyKeyboard = kb
+	}
+}
+
+// MessageManager 管理 Bot 消息的发送、编辑、删除和自动删除定时器。
+type MessageManager struct {
+	bot    *tgbotapi.BotAPI
+	cfg    *config.Config
+	mu     sync.RWMutex
+	timers map[int64]map[int]*time.Timer // chatID -> msgID -> timer
+}
+
+// NewMessageManager 创建 MessageManager 实例。
+func NewMessageManager(bot *tgbotapi.BotAPI, cfg *config.Config) *MessageManager {
+	return &MessageManager{
+		bot:    bot,
+		cfg:    cfg,
+		timers: make(map[int64]map[int]*time.Timer),
+	}
+}
+
+// getTTL 根据消息标签和当前配置返回自动删除的 TTL（秒）。0 表示不自动删除。
+func (m *MessageManager) getTTL(label MessageLabel) int {
+	switch label {
+	case LabelCommand:
+		if !m.cfg.Message.IsAutoDeleteEnabled() {
+			return 0
+		}
+		return m.cfg.Message.ResultDeleteAfter
+	case LabelProgress:
+		return m.cfg.Message.ProgressUpdateInterval
+	case LabelInstall:
+		if !m.cfg.Message.InstallLogDelete {
+			return 0
+		}
+		return m.cfg.Message.ResultDeleteAfter
+	case LabelError:
+		return m.cfg.Message.ErrorDeleteAfter
+	case LabelNotify:
+		return m.cfg.Message.NotifyDeleteAfter
+	default:
+		return 0
+	}
+}
+
+// setTimer 为指定消息创建自动删除定时器。
+func (m *MessageManager) setTimer(chatID int64, msgID int, ttl int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.timers[chatID] == nil {
+		m.timers[chatID] = make(map[int]*time.Timer)
+	}
+
+	// 取消旧定时器
+	if old, ok := m.timers[chatID][msgID]; ok {
+		old.Stop()
+	}
+
+	m.timers[chatID][msgID] = time.AfterFunc(time.Duration(ttl)*time.Second, func() {
+		m.deleteAndCleanup(chatID, msgID)
+	})
+}
+
+// deleteAndCleanup 删除消息并清理定时器记录。
+func (m *MessageManager) deleteAndCleanup(chatID int64, msgID int) {
+	// 请求 Telegram 删除消息（忽略错误，消息可能已被手动删除）
+	_, err := m.bot.Request(tgbotapi.NewDeleteMessage(chatID, msgID))
+	if err != nil {
+		// 静默忽略：消息可能已被手动删除或不存在
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.timers[chatID] != nil {
+		delete(m.timers[chatID], msgID)
+		if len(m.timers[chatID]) == 0 {
+			delete(m.timers, chatID)
+		}
+	}
+}
+
+// stopTimer 停止并清理指定消息的定时器。
+func (m *MessageManager) stopTimer(chatID int64, msgID int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.timers[chatID] != nil {
+		if timer, ok := m.timers[chatID][msgID]; ok {
+			timer.Stop()
+			delete(m.timers[chatID], msgID)
+			if len(m.timers[chatID]) == 0 {
+				delete(m.timers, chatID)
+			}
+		}
+	}
+}
+
+// ReloadConfig 更新内部配置引用（不清理已有定时器）。
+func (m *MessageManager) ReloadConfig(cfg *config.Config) {
+	m.cfg = cfg
+}
+
+// Send 发送文本消息并根据 label 设置自动删除定时器。
+// 支持 WithInlineKeyboard 和 WithReplyKeyboard 函数选项。
+func (m *MessageManager) Send(chatID int64, text string, label MessageLabel, opts ...SendOption) (int, error) {
+	sc := &sendConfig{}
+	for _, opt := range opts {
+		opt(sc)
+	}
+
+	msg := tgbotapi.NewMessage(chatID, text)
+	msg.ParseMode = tgbotapi.ModeMarkdown
+
+	if sc.inlineKeyboard != nil {
+		msg.ReplyMarkup = *sc.inlineKeyboard
+	}
+	if sc.replyKeyboard != nil {
+		msg.ReplyMarkup = sc.replyKeyboard
+	}
+
+	sent, err := m.bot.Send(msg)
+	if err != nil {
+		return 0, err
+	}
+
+	ttl := m.getTTL(label)
+	if ttl > 0 {
+		m.setTimer(chatID, sent.MessageID, ttl)
+	}
+
+	return sent.MessageID, nil
+}
+
+// Edit 编辑已有消息的文本内容，同时重置自动删除定时器。
+func (m *MessageManager) Edit(chatID int64, msgID int, text string, label MessageLabel) error {
+	edit := tgbotapi.NewEditMessageText(chatID, msgID, text)
+	edit.ParseMode = tgbotapi.ModeMarkdown
+
+	if _, err := m.bot.Send(edit); err != nil {
+		return err
+	}
+
+	// 重置自动删除定时器
+	ttl := m.getTTL(label)
+	if ttl > 0 {
+		m.setTimer(chatID, msgID, ttl)
+	} else {
+		m.stopTimer(chatID, msgID)
+	}
+
+	return nil
+}
+
+// Delete 删除消息并清理关联的定时器。
+func (m *MessageManager) Delete(chatID int64, msgID int) error {
+	_, err := m.bot.Request(tgbotapi.NewDeleteMessage(chatID, msgID))
+	if err != nil {
+		return err
+	}
+
+	m.stopTimer(chatID, msgID)
+	return nil
+}

--- a/internal/telegram/message.go
+++ b/internal/telegram/message.go
@@ -105,20 +105,23 @@ func (m *MessageManager) setTimer(chatID int64, msgID int, ttl int) {
 
 // deleteAndCleanup 删除消息并清理定时器记录。
 func (m *MessageManager) deleteAndCleanup(chatID int64, msgID int) {
+	// 先清理定时器记录（无论 API 调用是否成功）
+	defer func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if m.timers[chatID] != nil {
+			delete(m.timers[chatID], msgID)
+			if len(m.timers[chatID]) == 0 {
+				delete(m.timers, chatID)
+			}
+		}
+	}()
+
 	// 请求 Telegram 删除消息（忽略错误，消息可能已被手动删除）
 	_, err := m.bot.Request(tgbotapi.NewDeleteMessage(chatID, msgID))
 	if err != nil {
 		// 静默忽略：消息可能已被手动删除或不存在
 		return
-	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.timers[chatID] != nil {
-		delete(m.timers[chatID], msgID)
-		if len(m.timers[chatID]) == 0 {
-			delete(m.timers, chatID)
-		}
 	}
 }
 

--- a/internal/telegram/message.go
+++ b/internal/telegram/message.go
@@ -1,6 +1,7 @@
 package telegram
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -61,30 +62,37 @@ func NewMessageManager(bot *tgbotapi.BotAPI, cfg *config.Config) *MessageManager
 }
 
 // getTTL 根据消息标签和当前配置返回自动删除的 TTL（秒）。0 表示不自动删除。
+// 使用读锁保护 cfg 访问，避免与 ReloadConfig 产生数据竞争。
 func (m *MessageManager) getTTL(label MessageLabel) int {
+	m.mu.RLock()
+	cfg := m.cfg
+	m.mu.RUnlock()
+
 	switch label {
 	case LabelCommand:
-		if !m.cfg.Message.IsAutoDeleteEnabled() {
+		if !cfg.Message.IsAutoDeleteEnabled() {
 			return 0
 		}
-		return m.cfg.Message.ResultDeleteAfter
+		return cfg.Message.ResultDeleteAfter
 	case LabelProgress:
-		return m.cfg.Message.ProgressUpdateInterval
+		// 进度消息 TTL = 刷新间隔，每次 Edit 会重置定时器
+		return cfg.Message.ProgressUpdateInterval
 	case LabelInstall:
-		if !m.cfg.Message.InstallLogDelete {
+		if !cfg.Message.InstallLogDelete {
 			return 0
 		}
-		return m.cfg.Message.ResultDeleteAfter
+		return cfg.Message.ResultDeleteAfter
 	case LabelError:
-		return m.cfg.Message.ErrorDeleteAfter
+		return cfg.Message.ErrorDeleteAfter
 	case LabelNotify:
-		return m.cfg.Message.NotifyDeleteAfter
+		return cfg.Message.NotifyDeleteAfter
 	default:
 		return 0
 	}
 }
 
 // setTimer 为指定消息创建自动删除定时器。
+// 取消旧定时器并设置新定时器，通过定时器指针比对防止旧回调误删新条目。
 func (m *MessageManager) setTimer(chatID int64, msgID int, ttl int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -98,24 +106,27 @@ func (m *MessageManager) setTimer(chatID int64, msgID int, ttl int) {
 		old.Stop()
 	}
 
-	m.timers[chatID][msgID] = time.AfterFunc(time.Duration(ttl)*time.Second, func() {
-		m.deleteAndCleanup(chatID, msgID)
+	var t *time.Timer
+	t = time.AfterFunc(time.Duration(ttl)*time.Second, func() {
+		m.deleteAndCleanup(chatID, msgID, t)
 	})
+	m.timers[chatID][msgID] = t
 }
 
 // deleteAndCleanup 删除消息并清理定时器记录。
-func (m *MessageManager) deleteAndCleanup(chatID int64, msgID int) {
-	// 先清理定时器记录（无论 API 调用是否成功）
-	defer func() {
-		m.mu.Lock()
-		defer m.mu.Unlock()
-		if m.timers[chatID] != nil {
-			delete(m.timers[chatID], msgID)
-			if len(m.timers[chatID]) == 0 {
-				delete(m.timers, chatID)
-			}
-		}
-	}()
+// timer 参数用于校验回调对应的定时器仍是当前条目，防止旧回调误删。
+func (m *MessageManager) deleteAndCleanup(chatID int64, msgID int, timer *time.Timer) {
+	// 检查此定时器是否仍为当前条目
+	m.mu.Lock()
+	if m.timers[chatID] == nil || m.timers[chatID][msgID] != timer {
+		m.mu.Unlock()
+		return // 定时器已被替换，直接退出
+	}
+	delete(m.timers[chatID], msgID)
+	if len(m.timers[chatID]) == 0 {
+		delete(m.timers, chatID)
+	}
+	m.mu.Unlock()
 
 	// 请求 Telegram 删除消息（忽略错误，消息可能已被手动删除）
 	_, err := m.bot.Request(tgbotapi.NewDeleteMessage(chatID, msgID))
@@ -143,7 +154,9 @@ func (m *MessageManager) stopTimer(chatID int64, msgID int) {
 
 // ReloadConfig 更新内部配置引用（不清理已有定时器）。
 func (m *MessageManager) ReloadConfig(cfg *config.Config) {
+	m.mu.Lock()
 	m.cfg = cfg
+	m.mu.Unlock()
 }
 
 // Send 发送文本消息并根据 label 设置自动删除定时器。
@@ -152,6 +165,11 @@ func (m *MessageManager) Send(chatID int64, text string, label MessageLabel, opt
 	sc := &sendConfig{}
 	for _, opt := range opts {
 		opt(sc)
+	}
+
+	// 不可同时设置两种键盘
+	if sc.inlineKeyboard != nil && sc.replyKeyboard != nil {
+		return 0, fmt.Errorf("不能同时设置 Inline 键盘和 Reply 键盘")
 	}
 
 	msg := tgbotapi.NewMessage(chatID, text)

--- a/internal/telegram/message_test.go
+++ b/internal/telegram/message_test.go
@@ -1,0 +1,150 @@
+package telegram
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dnslin/aria2-tgbot/internal/config"
+)
+
+// newTestMessageConfig 创建测试用 MessageConfig。
+func newTestMessageConfig(autoDelete bool, resultTTL, progressTTL, errorTTL, notifyTTL int, installLogDelete bool) *config.MessageConfig {
+	ad := autoDelete
+	return &config.MessageConfig{
+		AutoDelete:             &ad,
+		ResultDeleteAfter:      resultTTL,
+		ProgressUpdateInterval: progressTTL,
+		ErrorDeleteAfter:       errorTTL,
+		NotifyDeleteAfter:      notifyTTL,
+		InstallLogDelete:       installLogDelete,
+	}
+}
+
+// newTestMessageManager 创建测试用 MessageManager（不需要真实 bot）。
+func newTestMessageManager(msgCfg *config.MessageConfig) *MessageManager {
+	cfg := &config.Config{Message: *msgCfg}
+	return &MessageManager{
+		bot:    nil,
+		cfg:    cfg,
+		timers: make(map[int64]map[int]*time.Timer),
+	}
+}
+
+func TestGetTTL_CommandWithAutoDelete(t *testing.T) {
+	msgCfg := newTestMessageConfig(true, 300, 30, 0, 0, false)
+	mgr := newTestMessageManager(msgCfg)
+
+	ttl := mgr.getTTL(LabelCommand)
+	if ttl != 300 {
+		t.Errorf("LabelCommand TTL 应为 300, 实际 %d", ttl)
+	}
+}
+
+func TestGetTTL_CommandAutoDeleteDisabled(t *testing.T) {
+	msgCfg := newTestMessageConfig(false, 300, 30, 0, 0, false)
+	mgr := newTestMessageManager(msgCfg)
+
+	ttl := mgr.getTTL(LabelCommand)
+	if ttl != 0 {
+		t.Errorf("AutoDelete 关闭时 LabelCommand TTL 应为 0, 实际 %d", ttl)
+	}
+}
+
+func TestGetTTL_Progress(t *testing.T) {
+	msgCfg := newTestMessageConfig(true, 300, 30, 0, 0, false)
+	mgr := newTestMessageManager(msgCfg)
+
+	ttl := mgr.getTTL(LabelProgress)
+	if ttl != 30 {
+		t.Errorf("LabelProgress TTL 应为 30, 实际 %d", ttl)
+	}
+}
+
+func TestGetTTL_InstallWithLogDelete(t *testing.T) {
+	msgCfg := newTestMessageConfig(true, 300, 30, 0, 0, true)
+	mgr := newTestMessageManager(msgCfg)
+
+	ttl := mgr.getTTL(LabelInstall)
+	if ttl != 300 {
+		t.Errorf("InstallLogDelete=true 时 LabelInstall TTL 应为 300, 实际 %d", ttl)
+	}
+}
+
+func TestGetTTL_InstallLogDeleteDisabled(t *testing.T) {
+	msgCfg := newTestMessageConfig(true, 300, 30, 0, 0, false)
+	mgr := newTestMessageManager(msgCfg)
+
+	ttl := mgr.getTTL(LabelInstall)
+	if ttl != 0 {
+		t.Errorf("InstallLogDelete=false 时 LabelInstall TTL 应为 0, 实际 %d", ttl)
+	}
+}
+
+func TestGetTTL_ErrorZero(t *testing.T) {
+	msgCfg := newTestMessageConfig(true, 300, 30, 0, 0, false)
+	mgr := newTestMessageManager(msgCfg)
+
+	ttl := mgr.getTTL(LabelError)
+	if ttl != 0 {
+		t.Errorf("ErrorDeleteAfter=0 时 LabelError TTL 应为 0, 实际 %d", ttl)
+	}
+}
+
+func TestGetTTL_ErrorNonZero(t *testing.T) {
+	msgCfg := newTestMessageConfig(true, 300, 30, 120, 0, false)
+	mgr := newTestMessageManager(msgCfg)
+
+	ttl := mgr.getTTL(LabelError)
+	if ttl != 120 {
+		t.Errorf("ErrorDeleteAfter=120 时 LabelError TTL 应为 120, 实际 %d", ttl)
+	}
+}
+
+func TestGetTTL_NotifyZero(t *testing.T) {
+	msgCfg := newTestMessageConfig(true, 300, 30, 0, 0, false)
+	mgr := newTestMessageManager(msgCfg)
+
+	ttl := mgr.getTTL(LabelNotify)
+	if ttl != 0 {
+		t.Errorf("NotifyDeleteAfter=0 时 LabelNotify TTL 应为 0, 实际 %d", ttl)
+	}
+}
+
+func TestGetTTL_NotifyNonZero(t *testing.T) {
+	msgCfg := newTestMessageConfig(true, 300, 30, 0, 600, false)
+	mgr := newTestMessageManager(msgCfg)
+
+	ttl := mgr.getTTL(LabelNotify)
+	if ttl != 600 {
+		t.Errorf("NotifyDeleteAfter=600 时 LabelNotify TTL 应为 600, 实际 %d", ttl)
+	}
+}
+
+func TestGetTTL_UnknownLabel(t *testing.T) {
+	msgCfg := newTestMessageConfig(true, 300, 30, 0, 0, false)
+	mgr := newTestMessageManager(msgCfg)
+
+	ttl := mgr.getTTL(MessageLabel("unknown"))
+	if ttl != 0 {
+		t.Errorf("未知 label TTL 应为 0, 实际 %d", ttl)
+	}
+}
+
+func TestReloadConfig(t *testing.T) {
+	msgCfg := newTestMessageConfig(true, 100, 10, 0, 0, false)
+	mgr := newTestMessageManager(msgCfg)
+
+	if mgr.getTTL(LabelCommand) != 100 {
+		t.Error("重载前 TTL 应为 100")
+	}
+
+	newCfg := &config.Config{Message: config.MessageConfig{
+		AutoDelete:        &[]bool{true}[0],
+		ResultDeleteAfter: 500,
+	}}
+	mgr.ReloadConfig(newCfg)
+
+	if mgr.getTTL(LabelCommand) != 500 {
+		t.Errorf("重载后 TTL 应为 500, 实际 %d", mgr.getTTL(LabelCommand))
+	}
+}


### PR DESCRIPTION
## Summary

实现 Telegram Bot 的 Inline Keyboard 工厂函数、回调查询处理、消息自动删除定时器管理三个核心模块。

## Changes

- **keyboard.go** — 6 个键盘工厂函数（确认/取消、任务操作、分页导航、Reply Keyboard）
- **callback.go** — HandleCallback 完整重写，8 个回调路由 handler + parseCallbackData 解析函数
- **message.go** — MessageManager，支持 Send/Edit/Delete/ReloadConfig，5 种消息类型标签，自动删除定时器管理
- **handler.go** — 注入 MessageManager，删除旧的 sendReply 占位方法
- **command.go** — 全部 30 个命令 handler 改用 msgMgr.Send

## Concurrent Safety

- 定时器指针比对防止旧回调误删新条目
- getTTL/ReloadConfig 使用 sync.RWMutex 保护 cfg 访问
- 双键盘冲突返回明确错误

## Test Coverage

| Test File | Tests | Coverage |
|-----------|-------|----------|
| keyboard_test.go | 13 + 3 benches | 全部键盘函数 + 边界情况 |
| callback_test.go | 13 | parseCallbackData 解析 + validActions |
| message_test.go | 11 | getTTL 全部 label + ReloadConfig |

## Test Plan

- [x] `go build ./...` 编译通过
- [x] `go vet ./...` 无警告
- [x] `go test -count=1 ./...` 94 个测试全部通过
- [x] 键盘函数 benchmark 通过
- [x] 空列表/首页/末页/单页等边界情况覆盖

Closes #4